### PR TITLE
Redesign README preview with modern markdown styling

### DIFF
--- a/frontend/src/components/editor/outputs/ReadmeOutputLatex.tsx
+++ b/frontend/src/components/editor/outputs/ReadmeOutputLatex.tsx
@@ -4,56 +4,56 @@ import { Mail } from "lucide-react";
 
 export default function ReadmeOutput() {
   return (
-    <div className="bg-gray-500 min-h-full p-12">
-      {/* LaTeX-style PDF document */}
-      <div className="max-w-[8.5in] mx-auto bg-white shadow-2xl border border-gray-400 min-h-screen" style={{ fontFamily: 'Georgia, "Times New Roman", serif' }}>
-        {/* Document content with LaTeX-style margins (1 inch) */}
-        <div className="p-16">
-          {/* LaTeX-style header */}
-          <div className="text-center mb-8">
-            <h1 className="text-4xl font-bold text-black mb-2" style={{ letterSpacing: '0.05em' }}>
-              MADS HERMANSEN
+    <div className="bg-[#0d1117] min-h-full">
+      {/* Markdown-style document container */}
+      <div className="max-w-4xl mx-auto bg-[#0d1117] min-h-screen">
+        {/* Markdown content with proper spacing */}
+        <div className="px-8 py-10">
+          {/* Markdown-style header */}
+          <div className="mb-10">
+            <h1 className="text-5xl font-bold text-[#c9d1d9] mb-4 pb-2 border-b border-[#21262d]">
+              Mads Hermansen
             </h1>
-            <div className="h-0.5 bg-black w-full my-3"></div>
-            <div className="text-sm text-gray-700 space-y-1">
-              <p>Full Stack Developer • Masters Student • Tech Enthusiast</p>
-              <p>
-                <Mail className="inline w-3 h-3 mr-1" />
-                <Link href="mailto:mdj.hermansen@gmail.com" className="hover:underline">
-                  mdj.hermansen@gmail.com
-                </Link>
-                {" • "}
-                Trondheim, Norway
-              </p>
-              <p className="text-xs mt-2">
-                <Link href="https://github.com/madshermansen" className="hover:underline mr-3">
-                  github.com/madshermansen
-                </Link>
-                <Link href="https://linkedin.com/in/mdhermansen" className="hover:underline">
-                  linkedin.com/in/mdhermansen
-                </Link>
-              </p>
+            <p className="text-xl text-[#8b949e] mb-6">
+              Full Stack Developer • Masters Student • Tech Enthusiast
+            </p>
+            <div className="flex flex-wrap gap-4 text-[#58a6ff]">
+              <Link href="mailto:mdj.hermansen@gmail.com" className="hover:underline flex items-center gap-1">
+                <Mail className="inline w-4 h-4" />
+                mdj.hermansen@gmail.com
+              </Link>
+              <span className="text-[#8b949e]">•</span>
+              <span className="text-[#8b949e]">Trondheim, Norway</span>
+              <span className="text-[#8b949e]">•</span>
+              <Link href="https://github.com/madshermansen" target="_blank" className="hover:underline flex items-center gap-1">
+                <FaGithub className="w-4 h-4" />
+                GitHub
+              </Link>
+              <span className="text-[#8b949e]">•</span>
+              <Link href="https://linkedin.com/in/mdhermansen" target="_blank" className="hover:underline flex items-center gap-1">
+                <FaLinkedin className="w-4 h-4" />
+                LinkedIn
+              </Link>
             </div>
-            <div className="h-0.5 bg-black w-full mt-3"></div>
           </div>
 
-          {/* Education Section - LaTeX style */}
-          <section className="mb-6">
-            <h2 className="text-lg font-bold text-black uppercase tracking-wide mb-2 border-b border-black pb-1">
+          {/* Education Section */}
+          <section className="mb-8">
+            <h2 className="text-2xl font-bold text-[#c9d1d9] mb-4 pb-2 border-b border-[#21262d]">
               Education
             </h2>
-            <div className="ml-0">
-              <div className="flex justify-between items-start mb-1">
+            <div className="space-y-1">
+              <div className="flex justify-between items-start">
                 <div>
-                  <p className="font-bold text-black">Norwegian University of Science and Technology (NTNU)</p>
-                  <p className="italic text-gray-800">Master of Science in Software Systems</p>
+                  <p className="text-lg font-semibold text-[#c9d1d9]">Norwegian University of Science and Technology (NTNU)</p>
+                  <p className="text-[#8b949e]">Master of Science in Software Systems</p>
                 </div>
-                <div className="text-right text-sm text-gray-700">
+                <div className="text-right text-sm text-[#8b949e]">
                   <p>Trondheim, Norway</p>
-                  <p className="italic">2024 – Present</p>
+                  <p>2024 – Present</p>
                 </div>
               </div>
-              <ul className="list-disc list-inside ml-4 text-sm text-gray-800 leading-relaxed">
+              <ul className="list-disc list-inside ml-5 mt-2 text-[#8b949e] space-y-1">
                 <li>Specializing in advanced software engineering, system architecture, and development methodologies</li>
                 <li>Focus on full-stack and mobile application development</li>
               </ul>
@@ -61,26 +61,26 @@ export default function ReadmeOutput() {
           </section>
 
           {/* Experience Section */}
-          <section className="mb-6">
-            <h2 className="text-lg font-bold text-black uppercase tracking-wide mb-2 border-b border-black pb-1">
+          <section className="mb-8">
+            <h2 className="text-2xl font-bold text-[#c9d1d9] mb-4 pb-2 border-b border-[#21262d]">
               Experience
             </h2>
-            <div className="ml-0">
-              <div className="flex justify-between items-start mb-1">
+            <div className="space-y-1">
+              <div className="flex justify-between items-start">
                 <div>
-                  <p className="font-bold text-black">Mobile Developer</p>
-                  <p className="italic text-gray-800">
-                    <Link href="https://ssesh.no" className="hover:underline">
+                  <p className="text-lg font-semibold text-[#c9d1d9]">Mobile Developer</p>
+                  <p className="text-[#8b949e]">
+                    <Link href="https://ssesh.no" className="text-[#58a6ff] hover:underline">
                       ssesh
                     </Link>
                   </p>
                 </div>
-                <div className="text-right text-sm text-gray-700">
+                <div className="text-right text-sm text-[#8b949e]">
                   <p>Trondheim, Norway</p>
-                  <p className="italic">2024 – Present</p>
+                  <p>2024 – Present</p>
                 </div>
               </div>
-              <ul className="list-disc list-inside ml-4 text-sm text-gray-800 leading-relaxed">
+              <ul className="list-disc list-inside ml-5 mt-2 text-[#8b949e] space-y-1">
                 <li>Contributing to mobile application development using React Native and Expo</li>
                 <li>Developing digital infrastructure and backend systems for startup operations</li>
                 <li>Collaborating with cross-functional teams on innovative product features</li>
@@ -89,42 +89,46 @@ export default function ReadmeOutput() {
           </section>
 
           {/* Technical Skills Section */}
-          <section className="mb-6">
-            <h2 className="text-lg font-bold text-black uppercase tracking-wide mb-2 border-b border-black pb-1">
+          <section className="mb-8">
+            <h2 className="text-2xl font-bold text-[#c9d1d9] mb-4 pb-2 border-b border-[#21262d]">
               Technical Skills
             </h2>
-            <div className="ml-0 text-sm">
-              <div className="grid grid-cols-[120px_1fr] gap-y-2 gap-x-4">
-                <div className="font-bold text-black">Frontend:</div>
-                <div className="text-gray-800">React, Next.js, TypeScript, Tailwind CSS, Framer Motion</div>
-
-                <div className="font-bold text-black">Backend:</div>
-                <div className="text-gray-800">Node.js, Express, MySQL, Planetscale, Sanity CMS</div>
-
-                <div className="font-bold text-black">Mobile:</div>
-                <div className="text-gray-800">React Native, Expo, iOS, Android</div>
-
-                <div className="font-bold text-black">Tools:</div>
-                <div className="text-gray-800">Git, VS Code, Figma, Vercel, Zendesk</div>
-
-                <div className="font-bold text-black">Languages:</div>
-                <div className="text-gray-800">JavaScript, TypeScript, Python, SQL</div>
+            <div className="space-y-3">
+              <div>
+                <span className="text-[#58a6ff] font-semibold">Frontend:</span>
+                <span className="text-[#8b949e] ml-2">React, Next.js, TypeScript, Tailwind CSS, Framer Motion</span>
+              </div>
+              <div>
+                <span className="text-[#58a6ff] font-semibold">Backend:</span>
+                <span className="text-[#8b949e] ml-2">Node.js, Express, MySQL, Planetscale, Sanity CMS</span>
+              </div>
+              <div>
+                <span className="text-[#58a6ff] font-semibold">Mobile:</span>
+                <span className="text-[#8b949e] ml-2">React Native, Expo, iOS, Android</span>
+              </div>
+              <div>
+                <span className="text-[#58a6ff] font-semibold">Tools:</span>
+                <span className="text-[#8b949e] ml-2">Git, VS Code, Figma, Vercel, Zendesk</span>
+              </div>
+              <div>
+                <span className="text-[#58a6ff] font-semibold">Languages:</span>
+                <span className="text-[#8b949e] ml-2">JavaScript, TypeScript, Python, SQL</span>
               </div>
             </div>
           </section>
 
           {/* Projects Section */}
-          <section className="mb-6">
-            <h2 className="text-lg font-bold text-black uppercase tracking-wide mb-2 border-b border-black pb-1">
+          <section className="mb-8">
+            <h2 className="text-2xl font-bold text-[#c9d1d9] mb-4 pb-2 border-b border-[#21262d]">
               Notable Projects
             </h2>
-            <div className="ml-0 space-y-3">
+            <div className="space-y-4">
               <div>
-                <div className="flex justify-between items-start mb-1">
-                  <p className="font-bold text-black">Personal Portfolio Website</p>
-                  <p className="text-sm italic text-gray-700">2024</p>
+                <div className="flex justify-between items-start mb-2">
+                  <p className="text-lg font-semibold text-[#c9d1d9]">Personal Portfolio Website</p>
+                  <p className="text-sm text-[#8b949e]">2024</p>
                 </div>
-                <ul className="list-disc list-inside ml-4 text-sm text-gray-800 leading-relaxed">
+                <ul className="list-disc list-inside ml-5 text-[#8b949e] space-y-1">
                   <li>Built with Next.js, TypeScript, and Tailwind CSS featuring VS Code-inspired interface</li>
                   <li>Implemented Monokai Pro theme with split-screen code editor layout</li>
                   <li>Integrated Sanity CMS for dynamic project management</li>
@@ -132,11 +136,11 @@ export default function ReadmeOutput() {
               </div>
 
               <div>
-                <div className="flex justify-between items-start mb-1">
-                  <p className="font-bold text-black">Mobile Application Development</p>
-                  <p className="text-sm italic text-gray-700">2024</p>
+                <div className="flex justify-between items-start mb-2">
+                  <p className="text-lg font-semibold text-[#c9d1d9]">Mobile Application Development</p>
+                  <p className="text-sm text-[#8b949e]">2024</p>
                 </div>
-                <ul className="list-disc list-inside ml-4 text-sm text-gray-800 leading-relaxed">
+                <ul className="list-disc list-inside ml-5 text-[#8b949e] space-y-1">
                   <li>Developed cross-platform mobile applications using React Native and Expo</li>
                   <li>Implemented backend APIs with Node.js and Express for mobile data synchronization</li>
                 </ul>
@@ -145,44 +149,41 @@ export default function ReadmeOutput() {
           </section>
 
           {/* Additional Information */}
-          <section className="mb-6">
-            <h2 className="text-lg font-bold text-black uppercase tracking-wide mb-2 border-b border-black pb-1">
+          <section className="mb-8">
+            <h2 className="text-2xl font-bold text-[#c9d1d9] mb-4 pb-2 border-b border-[#21262d]">
               Additional Information
             </h2>
-            <div className="ml-0 text-sm">
-              <div className="grid grid-cols-[120px_1fr] gap-y-2 gap-x-4">
-                <div className="font-bold text-black">Interests:</div>
-                <div className="text-gray-800">Calisthenics, Open Source Contributions, Continuous Learning, Technology Innovation</div>
-
-                <div className="font-bold text-black">Languages:</div>
-                <div className="text-gray-800">English (Fluent), Norwegian (Fluent)</div>
+            <div className="space-y-3">
+              <div>
+                <span className="text-[#58a6ff] font-semibold">Interests:</span>
+                <span className="text-[#8b949e] ml-2">Calisthenics, Open Source Contributions, Continuous Learning, Technology Innovation</span>
+              </div>
+              <div>
+                <span className="text-[#58a6ff] font-semibold">Languages:</span>
+                <span className="text-[#8b949e] ml-2">English (Fluent), Norwegian (Fluent)</span>
               </div>
             </div>
           </section>
 
-          {/* References Section - LaTeX classic */}
-          <section className="mb-4">
-            <h2 className="text-lg font-bold text-black uppercase tracking-wide mb-2 border-b border-black pb-1">
+          {/* References Section */}
+          <section className="mb-8">
+            <h2 className="text-2xl font-bold text-[#c9d1d9] mb-4 pb-2 border-b border-[#21262d]">
               References
             </h2>
-            <p className="text-sm italic text-gray-700 ml-0">Available upon request</p>
+            <p className="text-[#8b949e]">Available upon request</p>
           </section>
 
-          {/* Footer - LaTeX style page numbering */}
-          <div className="mt-12 pt-4 border-t border-gray-400 flex justify-between items-center text-xs text-gray-500">
-            <div>
-              <p className="italic">Last updated: {new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}</p>
+          {/* Footer */}
+          <div className="mt-12 pt-6 border-t border-[#21262d]">
+            <div className="bg-[#161b22] rounded-lg p-4 border border-[#30363d]">
+              <p className="text-sm text-[#8b949e] text-center">
+                💡 <span className="text-[#58a6ff] font-semibold">Tip:</span> Explore the files in the sidebar to learn more about my work experience, projects, and technical skills!
+              </p>
             </div>
-            <div>
-              <p>Page 1 of 1</p>
+            <div className="mt-6 text-center text-xs text-[#484f58]">
+              <p>Last updated: {new Date().toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}</p>
+              <p className="mt-1">Built with Next.js, TypeScript, and Tailwind CSS</p>
             </div>
-          </div>
-
-          {/* LaTeX signature */}
-          <div className="text-center mt-2">
-            <p className="text-xs text-gray-400" style={{ fontFamily: 'Computer Modern, serif' }}>
-              Typeset with L<span className="text-[0.7em] relative" style={{ top: '0.15em' }}>A</span>T<span className="text-[0.8em] relative" style={{ top: '-0.15em' }}>E</span>X
-            </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
- Reduced excessive padding from p-16 to px-8 py-10 for better margins
- Applied GitHub Dark theme color palette for authentic markdown look
- Replaced LaTeX-style serif fonts with clean sans-serif typography
- Improved section spacing and visual hierarchy
- Added consistent heading styles with subtle underlines
- Enhanced readability with proper text colors and link styling
- Removed heavy borders and shadows for cleaner appearance

The preview now resembles a proper GitHub markdown file instead of a PDF document.